### PR TITLE
[장바구니] - 비회원 장바구니 주문하기를 누를 경우, 비회원 정보를 리턴하도록 변경

### DIFF
--- a/src/main/java/com/yes255/yes255booksusersserver/presentation/dto/response/ReadOrderUserInfoResponse.java
+++ b/src/main/java/com/yes255/yes255booksusersserver/presentation/dto/response/ReadOrderUserInfoResponse.java
@@ -1,8 +1,20 @@
 package com.yes255.yes255booksusersserver.presentation.dto.response;
 
+import com.yes255.yes255booksusersserver.persistance.domain.Customer;
 import lombok.Builder;
 
 @Builder
 public record ReadOrderUserInfoResponse(Long userId, String name, String email, String phoneNumber,
                                         Integer points, String role) {
+
+    public static ReadOrderUserInfoResponse fromNoneMember(Customer customer) {
+        return ReadOrderUserInfoResponse.builder()
+            .userId(customer.getUserId())
+            .name("")
+            .email("")
+            .phoneNumber("")
+            .points(0)
+            .role("NONE_MEMBER")
+            .build();
+    }
 }


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [x] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 주문페이지를 올 경우, 토큰이 존재하면 유저 정보를 가져오는데 이때 에러가 발생하였습니다.
- 비회원 장바구니 주문하기를 누를 경우, 비회원 정보를 리턴하도록 변경하였습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->